### PR TITLE
Disable coverage and improve tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,3 @@ script:
   - tox
 notifications:
     email: false
-after_success:
-  - codecov

--- a/pytracetable/core.py
+++ b/pytracetable/core.py
@@ -13,50 +13,41 @@ class tracetable_context_manager():
 
     def __enter__(self):
         self.original_settrace = sys.settrace
+        # TODO: coverage is disabled for this project because sys.settrace() call below breaks it completely. See:
+        # https://github.com/nedbat/coveragepy/blob/39f8ce/doc/trouble.rst#things-that-dont-work
         sys.settrace(self.trace_calls)
+        return self
 
     def __exit__(self, *args, **kwargs):
         sys.settrace = self.original_settrace
 
-    @staticmethod
-    def show_returned(return_value, display_colors):
-        msg = '\t[RETURNED] {} ({})\n'.format(return_value, return_value.__class__.__name__)
+    def _print(self, msg, color=None):
+        color = color or ''
 
-        if display_colors:
-            print(Fore.BLUE + msg)
+        if self.display_colors:
+            print(color + msg)
             print(Style.RESET_ALL),
         else:
             print(msg)
 
     def show_added(self, added):
         for key, value in added.items():
-            msg = '\t[ADDED]    {} ({}): {}'.format(key, value.__class__.__name__, value)
-
-            if self.display_colors:
-                print(Fore.GREEN + msg)
-                print(Style.RESET_ALL),
-            else:
-                print(msg)
-
-    def show_removed(self, removed):
-        for item in removed:
-            msg = '\t[REMOVED]  {}'.format(item)
-
-            if self.display_colors:
-                print(Fore.RED + msg)
-                print(Style.RESET_ALL),
-            else:
-                print(msg)
+            msg = '\t[ADDED]    {}: {} ({})'.format(key, value, value.__class__.__name__)
+            self._print(msg, color=Fore.GREEN)
 
     def show_changed(self, changed):
         for key, (old, new) in changed.items():
             msg = '\t[CHANGED]  {}: {} ({}) --> {} ({})'.format(key, old, old.__class__.__name__, new, new.__class__.__name__)
+            self._print(msg, color=Fore.YELLOW)
 
-            if self.display_colors:
-                print(Fore.YELLOW + msg)
-                print(Style.RESET_ALL),
-            else:
-                print(msg)
+    def show_removed(self, removed):
+        for item in removed:
+            msg = '\t[REMOVED]  {}'.format(item)
+            self._print(msg, color=Fore.RED)
+
+    def show_returned(self, return_value):
+        msg = '\t[RETURNED] {} ({})\n'.format(return_value, return_value.__class__.__name__)
+        self._print(msg, color=Fore.BLUE)
 
     def trace_calls(self, frame, event, arg):
         if event != 'call' or frame.f_code.co_name != self.name:
@@ -83,8 +74,8 @@ class tracetable_context_manager():
                 changed[item] = [self.current_vars[item], local_vars[item]]
 
         if any([added, removed, changed]):
-            print('\n' + '-' * 50)
-            print('At {}, line {}'.format(func_name, line_no))
+            self._print('\n' + '-' * 50)
+            self._print('At {}, line {}'.format(func_name, line_no))
 
         if added:
             self.show_added(added)
@@ -104,9 +95,9 @@ def tracetable(display_colors=True):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
 
-            with tracetable_context_manager(func.__name__, display_colors=display_colors):
+            with tracetable_context_manager(func.__name__, display_colors=display_colors) as ctx:
                 return_value = func(*args, **kwargs)
-                tracetable_context_manager.show_returned(return_value, display_colors=display_colors)
+                ctx.show_returned(return_value)
 
             return return_value
         return wrapper

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,4 @@
 bump2version<1
-coverage==5.0.3
-codecov==2.0.16
 flake8==3.7.9
 isort==4.3.21
 mock==1.3.0

--- a/runtests.py
+++ b/runtests.py
@@ -1,4 +1,3 @@
 import nose
 
 nose.main()
-

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@
 import unittest
 
 import mock
+from colorama import Fore
 
 from pytracetable.core import tracetable, tracetable_context_manager
 
@@ -51,7 +52,7 @@ class WeirdSumMethod(object):
         return var_added_inside_function
 
 
-class tracetableTestCase(unittest.TestCase):
+class TracetableTestCase(unittest.TestCase):
     @mock.patch.object(tracetable_context_manager, 'show_changed')
     @mock.patch.object(tracetable_context_manager, 'show_removed')
     @mock.patch.object(tracetable_context_manager, 'show_returned')
@@ -170,3 +171,11 @@ class tracetableTestCase(unittest.TestCase):
 
         self.assertEquals(weird_sum_method.do_it.__name__, 'do_it')
         self.assertEquals(weird_sum_method.do_it.__doc__, ' Helper method in order to show tracetable decorators in action ')
+
+    @mock.patch.object(tracetable_context_manager, '_print')
+    def test_print_calls(self, print_patched):
+        weird_sum_function(12)
+        print_patched.assert_any_call('\t[ADDED]    var_parameter_1: 12 (int)', color=Fore.GREEN)
+        print_patched.assert_any_call('\t[CHANGED]  var_added_inside_function: 101 (int) --> 102 (int)', color=Fore.YELLOW)
+        print_patched.assert_any_call('\t[REMOVED]  var_parameter_1', color=Fore.RED)
+        print_patched.assert_any_call('\t[RETURNED] 156 (int)\n', color=Fore.BLUE)

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,7 @@ commands =
     {envpython} --version
     lint: {env:COMMAND:flake8} pytracetable
     lint: {env:COMMAND:isort} -c -q
-    test: {env:COMMAND:coverage} run runtests.py
-    test: {env:COMMAND:coverage} report
+    test: {envpython} runtests.py
 
 setenv =
        PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
Coverage is disabled for this project because we call `sys.settrace()` and this breaks coverage completely.
See https://github.com/nedbat/coveragepy/blob/39f8ce/doc/trouble.rst#things-that-dont-work